### PR TITLE
Drop IE11 support

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -6,13 +6,6 @@ const browsers = [
   'last 1 Safari versions',
 ];
 
-const isCI = Boolean(process.env.CI);
-const isProduction = process.env.EMBER_ENV === 'production';
-
-if (isCI || isProduction) {
-  browsers.push('ie 11');
-}
-
 module.exports = {
   browsers,
 };


### PR DESCRIPTION
We agreed we don't need to support IE11 – this removes it from the targets for CI and production builds.