### PR TITLE
add staging system URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Make use of the many generators for code, try `ember help generate` for more det
 
 Specify what it takes to deploy your app.
 
+#### Staging system
+
+The staging system runs at [https://zealous-mahavira-6ac0ef.netlify.app](https://zealous-mahavira-6ac0ef.netlify.app).
+
 ## Further Reading / Useful Links
 
 * [ember.js](https://emberjs.com/)


### PR DESCRIPTION
Deployment with Netlify has been set up. This just adds the URL of the [staging system](https://zealous-mahavira-6ac0ef.netlify.app) to the README.

closes #3