### PR TITLE
add netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "yarn run build"
+  publish = "dist"
+
+# serve index.html for every request
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
This adds the missing Netlify config which we need to allow reloading on Ember routes. HTML files for these routes don't actually exist on Netlify's servers so we need to make sure all HTML requests for all routes are served with the `index.html` in the root of the project as the actual routing happens client-side in the browser in our case.