### PR TITLE
move button styles into button component

### DIFF
--- a/app/components/auth.css
+++ b/app/components/auth.css
@@ -1,10 +1,3 @@
 .auth__input {
   @apply mb-11;
 }
-
-.auth__confirm-button {
-  @apply
-    uppercase
-    text-white
-  ;
-}

--- a/app/components/auth.hbs
+++ b/app/components/auth.hbs
@@ -32,7 +32,6 @@
           />
 
           <Uc::Button
-            local-class="auth__confirm-button"
             disabled={{this.isIpAddressConfirmDisabled}}
             data-test-confirm-button
             type="submit"
@@ -50,7 +49,6 @@
 
           <Uc::Button
             @isLoading={{this.submitTask.isRunning}}
-            local-class="auth__confirm-button"
             disabled={{this.isPasswordConfirmDisabled}}
             type="submit"
             data-test-confirm-button

--- a/app/components/uc/button.css
+++ b/app/components/uc/button.css
@@ -1,7 +1,8 @@
 .uc-button {
   @apply inline-block
     w-full h-11
-    text-sm tracking-widest font-semibold;
+    text-sm tracking-widest font-semibold uppercase
+    text-white;
 
   border-radius: 21px;
   background-image: linear-gradient(180deg, #226dc4 0%, #1e5fab 100%);


### PR DESCRIPTION
This moves the styles for text on buttons currently kept inside the `<Auth>` component into the generic `<Uc::Button>` component. Since all buttons in the app look the same, the styles should be kept right in the button to avoid duplication.