### PR TITLE
Add QR code component

### DIFF
--- a/app/components/uc/network-qr-code.css
+++ b/app/components/uc/network-qr-code.css
@@ -1,0 +1,8 @@
+.qr-code {
+  @apply border p-5 border-gray-light border-opacity-50 shadow-sm rounded-md flex justify-center py-16;
+}
+
+.canvas {
+  width: 50vw;
+  height: 50vw;
+}

--- a/app/components/uc/network-qr-code.css
+++ b/app/components/uc/network-qr-code.css
@@ -3,6 +3,8 @@
 }
 
 .canvas {
+  @apply mb-6;
+
   width: 50vw;
   height: 50vw;
 }

--- a/app/components/uc/network-qr-code.hbs
+++ b/app/components/uc/network-qr-code.hbs
@@ -1,3 +1,13 @@
 <div local-class="qr-code">
-  <canvas local-class="canvas" {{did-insert (perform this.drawQrCode)}} data-test-canvas></canvas>
+  <canvas local-class="canvas" {{did-insert (perform this.drawTask)}} data-test-canvas></canvas>
 </div>
+
+{{#if this.canShare}}
+  <Uc::Button
+    data-test-share-qr-code-button
+    type="button"
+    {{on "click" (perform this.shareTask)}}
+  >
+    {{t "qr_code.share"}}
+  </Uc::Button>
+{{/if}}

--- a/app/components/uc/network-qr-code.hbs
+++ b/app/components/uc/network-qr-code.hbs
@@ -1,0 +1,3 @@
+<div local-class="qr-code">
+  <canvas local-class="canvas"></canvas>
+</div>

--- a/app/components/uc/network-qr-code.hbs
+++ b/app/components/uc/network-qr-code.hbs
@@ -1,3 +1,3 @@
 <div local-class="qr-code">
-  <canvas local-class="canvas"></canvas>
+  <canvas local-class="canvas" {{did-insert (perform this.drawQrCode)}} data-test-canvas></canvas>
 </div>

--- a/app/components/uc/network-qr-code.js
+++ b/app/components/uc/network-qr-code.js
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { task } from "ember-concurrency-decorators";
+import { waitForEvent } from "ember-concurrency";
 
 export default class NetworkQrCodeComponent extends Component {
   @service qrCode;
@@ -14,7 +15,13 @@ export default class NetworkQrCodeComponent extends Component {
 
   @task({ keepLatest: true })
   *drawTask(canvas) {
-    const { width, height } = canvas;
-    yield this.qrCode.toCanvas(canvas, this.settingsString, { width, height });
+    while (true) {
+      const { width, height } = canvas;
+      yield this.qrCode.toCanvas(canvas, this.settingsString, {
+        width,
+        height,
+      });
+      yield waitForEvent(window, "resize");
+    }
   }
 }

--- a/app/components/uc/network-qr-code.js
+++ b/app/components/uc/network-qr-code.js
@@ -1,0 +1,20 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+import { task } from "ember-concurrency-decorators";
+
+export default class NetworkQrCodeComponent extends Component {
+  @service qrCode;
+
+  get settingsString() {
+    const { ssid, encryption, password, isHidden = false } = this.args;
+    const hidden = isHidden ? "H:true;" : "";
+
+    return `WIFI:T:${encryption.toUpperCase()};${hidden}S:${ssid};P:${password};;`;
+  }
+
+  @task({ keepLatest: true })
+  *drawTask(canvas) {
+    const { width, height } = canvas;
+    yield this.qrCode.toCanvas(canvas, this.settingsString, { width, height });
+  }
+}

--- a/app/components/uc/network-qr-code.js
+++ b/app/components/uc/network-qr-code.js
@@ -1,16 +1,45 @@
 import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
+import { tracked } from "@glimmer/tracking";
 import { task } from "ember-concurrency-decorators";
 import { waitForEvent } from "ember-concurrency";
+import dataUriToBlob from "data-uri-to-blob";
 
 export default class NetworkQrCodeComponent extends Component {
   @service qrCode;
+  @service navigator;
+
+  @tracked canShare = false;
+
+  constructor() {
+    super(...arguments);
+
+    this.prepareSharingTask.perform().catch(() => {
+      /* If this fails, sharing simply won't be enabled… */
+    });
+  }
 
   get settingsString() {
     const { ssid, encryption, password, isHidden = false } = this.args;
     const hidden = isHidden ? "H:true;" : "";
 
     return `WIFI:T:${encryption.toUpperCase()};${hidden}S:${ssid};P:${password};;`;
+  }
+
+  @task({ drop: true })
+  *prepareSharingTask() {
+    try {
+      let qrCode = yield this.qrCode.toDataURL(this.settingsString, {
+        type: "image/png",
+      });
+      let qrCodeBlob = dataUriToBlob(qrCode);
+      this.qrCodeImage = new File([qrCodeBlob], `${this.args.ssid}.png`, {
+        type: "image/png",
+      });
+      this.canShare = this.navigator.canShare({ files: [this.qrCodeImage] });
+    } catch (e) {
+      //TODO: handle error somehow…
+    }
   }
 
   @task({ keepLatest: true })
@@ -22,6 +51,17 @@ export default class NetworkQrCodeComponent extends Component {
         height,
       });
       yield waitForEvent(window, "resize");
+    }
+  }
+
+  @task({ drop: true })
+  *shareTask() {
+    try {
+      yield this.navigator.share({
+        files: [this.qrCodeImage],
+      });
+    } catch (e) {
+      //TODO: handle error somehow…
     }
   }
 }

--- a/app/services/navigator.js
+++ b/app/services/navigator.js
@@ -1,0 +1,11 @@
+import Service from "@ember/service";
+
+export default class NavigatorService extends Service {
+  canShare() {
+    return navigator.canShare?.(...arguments);
+  }
+
+  share() {
+    return navigator.share?.(...arguments);
+  }
+}

--- a/app/services/qr-code.js
+++ b/app/services/qr-code.js
@@ -5,4 +5,8 @@ export default class QrCodeService extends Service {
   toCanvas() {
     return QRCode.toCanvas(...arguments);
   }
+
+  toDataURL() {
+    return QRCode.toDataURL(...arguments);
+  }
 }

--- a/app/services/qr-code.js
+++ b/app/services/qr-code.js
@@ -1,0 +1,8 @@
+import Service from "@ember/service";
+import QRCode from "qrcode";
+
+export default class QrCodeService extends Service {
+  toCanvas() {
+    return QRCode.toCanvas(...arguments);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "^10.2.5",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
+    "data-uri-to-blob": "^0.0.4",
     "ember-auto-import": "^1.11.2",
     "ember-cli": "~3.26.1",
     "ember-cli-app-version": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
+    "@ember/render-modifiers": "^1.0.2",
     "@ember/test-helpers": "^2.2.5",
     "@fullhuman/postcss-purgecss": "^4.0.3",
     "@glimmer/component": "^1.0.4",
@@ -74,6 +75,7 @@
     "postcss-import": "^14.0.2",
     "pretender": "^3.4.3",
     "prettier": "^2.2.1",
+    "qrcode": "^1.4.4",
     "qunit": "^2.14.1",
     "qunit-dom": "^1.6.0",
     "stylelint": "^13.13.1",

--- a/tests/integration/components/uc/network-qr-code-test.js
+++ b/tests/integration/components/uc/network-qr-code-test.js
@@ -1,0 +1,52 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import Service from "@ember/service";
+import { hbs } from "ember-cli-htmlbars";
+
+module("Integration | Component | uc/network-qr-code", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it renders a canvas with the QR code", async function (assert) {
+    await render(
+      hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" />`
+    );
+
+    assert.dom("[data-test-canvas]").exists();
+  });
+
+  test("it draws the QR code when rendering", async function (assert) {
+    this.owner.register(
+      "service:qr-code",
+      class MockQrCodeService extends Service {
+        toCanvas(canvas, settingsString) {
+          assert.equal(settingsString, "WIFI:T:WPA;S:mynetwork;P:mypass;;");
+        }
+      }
+    );
+
+    await render(
+      hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" />`
+    );
+  });
+
+  test("it draws the QR code when rendering for a hidden network", async function (assert) {
+    assert.expect(1);
+
+    this.owner.register(
+      "service:qr-code",
+      class MockQrCodeService extends Service {
+        toCanvas(canvas, settingsString) {
+          assert.equal(
+            settingsString,
+            "WIFI:T:WPA;H:true;S:mynetwork;P:mypass;;"
+          );
+        }
+      }
+    );
+
+    await render(
+      hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+    );
+  });
+});

--- a/tests/integration/components/uc/network-qr-code-test.js
+++ b/tests/integration/components/uc/network-qr-code-test.js
@@ -1,11 +1,23 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render, triggerEvent } from "@ember/test-helpers";
+import { render, triggerEvent, click } from "@ember/test-helpers";
 import Service from "@ember/service";
 import { hbs } from "ember-cli-htmlbars";
 
+class MockQrCodeService extends Service {
+  toCanvas() {}
+
+  toDataURL() {
+    return "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEUAAACnej3aAAAAAXRSTlMAQObYZgAAAApJREFUCNdjYAAAAAIAAeIhvDMAAAAASUVORK5CYII="; // 1x1 pixel white
+  }
+}
+
 module("Integration | Component | uc/network-qr-code", function (hooks) {
   setupRenderingTest(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register("service:qr-code", MockQrCodeService);
+  });
 
   test("it renders a canvas with the QR code", async function (assert) {
     await render(
@@ -18,7 +30,7 @@ module("Integration | Component | uc/network-qr-code", function (hooks) {
   test("it draws the QR code when rendering", async function (assert) {
     this.owner.register(
       "service:qr-code",
-      class MockQrCodeService extends Service {
+      class extends MockQrCodeService {
         toCanvas(canvas, settingsString) {
           assert.equal(settingsString, "WIFI:T:WPA;S:mynetwork;P:mypass;;");
         }
@@ -35,7 +47,7 @@ module("Integration | Component | uc/network-qr-code", function (hooks) {
 
     this.owner.register(
       "service:qr-code",
-      class MockQrCodeService extends Service {
+      class extends MockQrCodeService {
         toCanvas(canvas, settingsString) {
           assert.equal(
             settingsString,
@@ -54,7 +66,7 @@ module("Integration | Component | uc/network-qr-code", function (hooks) {
     let calls = 0;
     this.owner.register(
       "service:qr-code",
-      class MockQrCodeService extends Service {
+      class extends MockQrCodeService {
         toCanvas() {
           calls++;
         }
@@ -73,4 +85,95 @@ module("Integration | Component | uc/network-qr-code", function (hooks) {
       "The QR code was drawn twice – on initial render and when the window was resized"
     );
   });
+
+  module("if the navigator supports the Web Sharing API Lvl. 2", function () {
+    module("and can share images", function (hooks) {
+      hooks.beforeEach(function () {
+        this.owner.register(
+          "service:navigator",
+          class extends Service {
+            canShare() {
+              return true;
+            }
+          }
+        );
+      });
+
+      test("it renders the share button", async function (assert) {
+        await render(
+          hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+        );
+
+        assert.dom("[data-test-share-qr-code-button]").exists();
+      });
+
+      test("clicking the share button shares the QR code image", async function (assert) {
+        this.owner.register(
+          "service:navigator",
+          class extends Service {
+            canShare() {
+              return true;
+            }
+
+            share(data) {
+              let [{ name: fileName, type: fileType }] = data.files;
+              assert.equal(fileName, "mynetwork.png");
+              assert.equal(fileType, "image/png");
+            }
+          }
+        );
+
+        await render(
+          hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+        );
+
+        await click("[data-test-share-qr-code-button]");
+      });
+    });
+
+    module("and cannot share images", function (hooks) {
+      hooks.beforeEach(function () {
+        this.owner.register(
+          "service:navigator",
+          class extends Service {
+            canShare() {
+              return false;
+            }
+          }
+        );
+      });
+
+      test("it does not render the share button", async function (assert) {
+        await render(
+          hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+        );
+
+        assert.dom("[data-test-share-qr-code-button]").doesNotExist();
+      });
+    });
+  });
+
+  module(
+    "if the navigator does not support the Web Sharing API Lvl. 2",
+    function (hooks) {
+      hooks.beforeEach(function () {
+        this.owner.register(
+          "service:navigator",
+          class extends Service {
+            canShare() {
+              return undefined;
+            }
+          }
+        );
+      });
+
+      test("it does not render the share button", async function (assert) {
+        await render(
+          hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+        );
+
+        assert.dom("[data-test-share-qr-code-button]").doesNotExist();
+      });
+    }
+  );
 });

--- a/tests/integration/components/uc/network-qr-code-test.js
+++ b/tests/integration/components/uc/network-qr-code-test.js
@@ -1,6 +1,6 @@
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
-import { render } from "@ember/test-helpers";
+import { render, triggerEvent } from "@ember/test-helpers";
 import Service from "@ember/service";
 import { hbs } from "ember-cli-htmlbars";
 
@@ -47,6 +47,30 @@ module("Integration | Component | uc/network-qr-code", function (hooks) {
 
     await render(
       hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+    );
+  });
+
+  test("it redraws the QR code when the window's size changes", async function (assert) {
+    let calls = 0;
+    this.owner.register(
+      "service:qr-code",
+      class MockQrCodeService extends Service {
+        toCanvas() {
+          calls++;
+        }
+      }
+    );
+
+    await render(
+      hbs`<Uc::NetworkQrCode @ssid="mynetwork" @password="mypass" @encryption="wpa" @isHidden={{true}} />`
+    );
+
+    await triggerEvent(window, "resize");
+
+    assert.equal(
+      calls,
+      2,
+      "The QR code was drawn twice – on initial render and when the window was resized"
     );
   });
 });

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -24,5 +24,8 @@
       "description": "Some information about where to find your password and/or how to recover it"
     },
     "incorrect_credentials": "Incorrect IP Address or Password"
+  },
+  "qr_code": {
+    "share": "Share QR code"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1014,6 +1014,14 @@
     mkdirp "^1.0.4"
     silent-error "^1.1.1"
 
+"@ember/render-modifiers@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@ember/render-modifiers/-/render-modifiers-1.0.2.tgz#2e87c48db49d922ce4850d707215caaac60d8444"
+  integrity sha512-6tEnHl5+62NTSAG2mwhGMFPhUrJQjoVqV+slsn+rlTknm2Zik+iwxBQEbwaiQOU1FUYxkS8RWcieovRNMR8inQ==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-modifier-manager-polyfill "^1.1.0"
+
 "@ember/test-helpers@^2.2.5":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@ember/test-helpers/-/test-helpers-2.2.5.tgz#9f915310b79fd6330e8e19857958e5f241c1d0de"
@@ -1966,7 +1974,7 @@ ansi-styles@^2.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
   integrity sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
 
-ansi-styles@^3.0.0, ansi-styles@^3.2.1:
+ansi-styles@^3.0.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -3894,7 +3902,25 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
-buffer-from@^1.0.0:
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
+  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
+
+buffer-from@^1.0.0, buffer-from@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
@@ -3913,7 +3939,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-buffer@^5.5.0:
+buffer@^5.4.3, buffer@^5.5.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
   integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
@@ -4028,7 +4054,7 @@ camelcase-keys@^6.2.2:
     map-obj "^4.0.0"
     quick-lru "^4.0.1"
 
-camelcase@^5.3.1:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -4269,6 +4295,15 @@ cli-width@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
   integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 cliui@^7.0.2:
   version "7.0.4"
@@ -5005,6 +5040,11 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dijkstrajs@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.1.tgz#d3cd81221e3ea40742cfcde556d4e99e98ddc71b"
+  integrity sha1-082BIh4+pAdCz83lVtTpnpjdxxs=
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -5238,7 +5278,7 @@ ember-cli-babel@^7.0.0, ember-cli-babel@^7.13.0, ember-cli-babel@^7.13.2, ember-
     rimraf "^3.0.1"
     semver "^5.5.0"
 
-ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.11.1, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.5.0:
+ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.19.0, ember-cli-babel@^7.20.5, ember-cli-babel@^7.5.0:
   version "7.26.6"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.26.6.tgz#322fbbd3baad9dd99e3276ff05bc6faef5e54b39"
   integrity sha512-040svtfj2RC35j/WMwdWJFusZaXmNoytLAMyBDGLMSlRvznudTxZjGlPV6UupmtTBApy58cEF8Fq4a+COWoEmQ==
@@ -5828,6 +5868,15 @@ ember-maybe-import-regenerator@^0.1.6:
     ember-cli-babel "^6.0.0-beta.4"
     regenerator-runtime "^0.9.5"
 
+ember-modifier-manager-polyfill@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-modifier-manager-polyfill/-/ember-modifier-manager-polyfill-1.2.0.tgz#cf4444e11a42ac84f5c8badd85e635df57565dda"
+  integrity sha512-bnaKF1LLKMkBNeDoetvIJ4vhwRPKIIumWr6dbVuW6W6p4QV8ZiO+GdF8J7mxDNlog9CeL9Z/7wam4YS86G8BYA==
+  dependencies:
+    ember-cli-babel "^7.10.0"
+    ember-cli-version-checker "^2.1.2"
+    ember-compatibility-helpers "^1.2.0"
+
 ember-page-title@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ember-page-title/-/ember-page-title-6.2.1.tgz#aa2d539fab8eddb618289cdba91adf699debf7da"
@@ -5996,6 +6045,11 @@ emblem@^0.12.1:
     broccoli-pegjs-import "^0.0.2"
     handlebars ">=2.0.0"
     optimist "^0.3.7"
+
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -7174,7 +7228,7 @@ gensync@^1.0.0-beta.2:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
-get-caller-file@^2.0.5:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -8295,6 +8349,11 @@ isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
   integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
+
+isarray@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isbinaryfile@^4.0.6:
   version "4.0.8"
@@ -10370,6 +10429,11 @@ pkg-up@^3.1.0:
   dependencies:
     find-up "^3.0.0"
 
+pngjs@^3.3.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
+  integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
+
 portfinder@^1.0.28:
   version "1.0.28"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.28.tgz#67c4622852bd5374dd1dd900f779f53462fac778"
@@ -10732,6 +10796,19 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qrcode@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.4.4.tgz#f0c43568a7e7510a55efc3b88d9602f71963ea83"
+  integrity sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==
+  dependencies:
+    buffer "^5.4.3"
+    buffer-alloc "^1.2.0"
+    buffer-from "^1.1.1"
+    dijkstrajs "^1.0.1"
+    isarray "^2.0.1"
+    pngjs "^3.3.0"
+    yargs "^13.2.4"
 
 qs@6.7.0:
   version "6.7.0"
@@ -11169,6 +11246,11 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 require-relative@^0.8.7:
   version "0.8.7"
   resolved "https://registry.yarnpkg.com/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
@@ -11512,7 +11594,7 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
-set-blocking@~2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
@@ -11992,6 +12074,15 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
@@ -12072,7 +12163,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
@@ -13241,6 +13332,11 @@ which-boxed-primitive@^1.0.2:
     is-string "^1.0.5"
     is-symbol "^1.0.3"
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
 which@^1.2.14, which@^1.2.9, which@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -13304,6 +13400,15 @@ workerpool@^6.0.0, workerpool@^6.0.3:
   version "6.1.4"
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.4.tgz#6a972b6df82e38d50248ee2820aa98e2d0ad3090"
   integrity sha512-jGWPzsUqzkow8HoAvqaPWTUPCrlPJaJ5tY8Iz7n1uCz3tTp6s3CDG0FF1NsX42WNlkRSW6Mr+CDZGnNoSsKa7g==
+
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -13407,10 +13512,34 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.7"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
   integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
+yargs@^13.2.4:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^16.2.0:
   version "16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4832,6 +4832,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+data-uri-to-blob@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/data-uri-to-blob/-/data-uri-to-blob-0.0.4.tgz#087a7bff42f41a6cc0b2e2fb7312a7c29904fbaa"
+  integrity sha1-CHp7/0L0GmzAsuL7cxKnwpkE+6o=
+
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"


### PR DESCRIPTION
This adds the `Uc::NetworkQrCode` for rendering the QR code with the network settings as well as sharing it via the Web Sharing API (Level 2).

<img width="403" alt="Bildschirmfoto 2021-05-27 um 17 24 54" src="https://user-images.githubusercontent.com/1510/119853708-b9a65600-bf10-11eb-8e8e-5fd05e0d0cad.png">

Unfortunately that API doesn't work in most browsers so in order to test this you'll need to be on Android Chrome or Safari Tech Preview. If the browser doesn't support sharing, we don't render the button.

closes #27