### PR TITLE
feat: change button designs for different states

### DIFF
--- a/app/components/uc/button.css
+++ b/app/components/uc/button.css
@@ -2,18 +2,61 @@
   @apply inline-block
     w-full h-11
     text-sm tracking-widest font-semibold uppercase
-    text-white;
+    text-inverted;
 
   border-radius: 21px;
-  background-image: linear-gradient(180deg, #226dc4 0%, #1e5fab 100%);
+  background-image:
+    linear-gradient(
+      to bottom,
+      var(--uc-blue) 0%,
+      var(--uc-blue-darker) 100%
+    );
+}
+
+.uc-button:focus,
+.uc-button:hover {
+  background-image:
+    linear-gradient(
+      to bottom,
+      var(--uc-blue-lighter) 0%,
+      var(--uc-blue) 100%
+    );
 }
 
 .uc-button:disabled {
-  @apply bg-gray-600;
+  @apply text-inverted-muted;
 
-  background-image: none;
+  background-image: linear-gradient(180deg, #c4c4c4 0%, #ababab 100%);
 }
 
-.uc-button.--loading {
-  @apply animate-pulse bg-yellow-400;
+.uc-button[aria-pressed="true"] {
+  --highlight: rgba(255, 255, 255, 0.15);
+  --transparent: rgba(255, 255, 255, 0);
+
+  @apply text-inverted-muted;
+
+  background-image:
+    linear-gradient(
+      90deg,
+      var(--transparent) 0%,
+      var(--highlight) 35%,
+      var(--transparent) 50%,
+      var(--transparent) 100%
+    ),
+    linear-gradient(to top, var(--uc-blue) 0%, var(--uc-blue-darker) 100%);
+  animation: button-pending 2.1s infinite linear;
+  background-size: 50% 100%, cover;
+  background-repeat: no-repeat, no-repeat;
+  user-select: none;
+  pointer-events: none;
+}
+
+@keyframes button-pending {
+  0% {
+    background-position: -50% 0, center;
+  }
+
+  100% {
+    background-position: 200% 0, center;
+  }
 }

--- a/app/components/uc/button.hbs
+++ b/app/components/uc/button.hbs
@@ -1,7 +1,7 @@
 <button
   type="button"
-  local-class="uc-button {{if @isLoading "--loading"}}"
-  disabled={{@isLoading}}
+  local-class="uc-button"
+  aria-pressed={{if @isLoading "true" "false"}}
   data-test-button
   ...attributes
 >

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,3 +1,5 @@
+@import "variables";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -1,0 +1,8 @@
+:root {
+  --uc-blue-lighter: #2b75cb;
+  --uc-blue: #226dc4;
+  --uc-blue-darker: #1e5fab;
+  --uc-blue-dark: #0c2644;
+  --uc-text-inverted: #fff;
+  --uc-text-inverted-muted: rgba(255, 255, 255, 0.7);
+}

--- a/config/tailwind/config.js
+++ b/config/tailwind/config.js
@@ -26,8 +26,10 @@ module.exports = {
       green: colors.emerald,
       blue: {
         ...colors.blue,
-        600: "#1E5FAB",
-        900: "#0C2644",
+        400: "var(--uc-blue-lighter)",
+        500: "var(--uc-blue)",
+        600: "var(--uc-blue-darker)",
+        900: "var(--uc-blue-dark)",
       },
       indigo: colors.indigo,
       purple: colors.violet,
@@ -708,7 +710,13 @@ module.exports = {
       1: "1",
       2: "2",
     },
-    textColor: (theme) => theme("colors"),
+    textColor: (theme) => {
+      return {
+        ...theme("colors"),
+        inverted: "var(--uc-text-inverted)",
+        "inverted-muted": "var(--uc-text-inverted-muted)",
+      };
+    },
     textOpacity: (theme) => theme("opacity"),
     transformOrigin: {
       center: "center",

--- a/tests/integration/components/auth/component-test.js
+++ b/tests/integration/components/auth/component-test.js
@@ -4,7 +4,6 @@ import { render, fillIn, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import UcentralRouterAuthenticator from "ucentral/authenticators/ucentral-router";
-import confirmButtonStyles from "ucentral/components/uc/button.css";
 import RSVP from "rsvp";
 import { next } from "@ember/runloop";
 
@@ -89,7 +88,7 @@ module("Integration | Component | auth", function (hooks) {
     next(() => {
       assert
         .dom("[data-test-confirm-button]")
-        .hasClass(confirmButtonStyles["--loading"]);
+        .hasAttribute("aria-pressed", "true");
       assert.dom("[data-test-confirm-button]").hasAttribute("disabled");
       deferred.resolve();
     });

--- a/tests/integration/components/uc/button-test.js
+++ b/tests/integration/components/uc/button-test.js
@@ -2,7 +2,6 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import buttonStyles from "ucentral/components/uc/button.css";
 
 module("Integration | Component | uc/button", function (hooks) {
   setupRenderingTest(hooks);
@@ -33,13 +32,16 @@ module("Integration | Component | uc/button", function (hooks) {
     await click("[data-test-button]");
   });
 
-  test("when is loading, applies loading class and is disabled", async function (assert) {
-    assert.expect(2);
-
+  test("when is loading, applies aria-pressed attribute", async function (assert) {
     this.isLoading = true;
     await this.renderSubject();
 
-    assert.dom("[data-test-button]").hasClass(buttonStyles["--loading"]);
-    assert.dom("[data-test-button]").hasAttribute("disabled");
+    assert.dom("[data-test-button]").hasAttribute("aria-pressed", "true");
+  });
+
+  test("when is loading, applies aria-pressed to false attribute", async function (assert) {
+    await this.renderSubject();
+
+    assert.dom("[data-test-button]").hasAttribute("aria-pressed", "false");
   });
 });


### PR DESCRIPTION
This changes the looks of buttons in different states, designs provided by Florian in #34 

- Removes loading class from button and replaces it with `aria-pressed` attribute
- creates file with css variables
- references css variables in tailwind config