### PR TITLE
Fix Lighthouse integration con CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: volta-cli/action@v1
     - run: yarn install
     - run: yarn lint
@@ -23,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - uses: volta-cli/action@v1
     - run: yarn install
     - run: yarn test:ember
@@ -33,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: volta-cli/action@v1
       - run: yarn install
       - run: yarn build


### PR DESCRIPTION
We have lighthouse-ci correctly configured and the GitHub app correctly installed. However, the Check doesn't show up so the results from running Lighthouse are a bit hard to discover (basically you have to go through the logs manually). We seems to be runnin into GoogleChrome/lighthouse-ci#172 and the fix for that is to explicitly check out the head SHA of the PR.