### PR TITLE
add `serialNumber` to auth endpoint

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -32,7 +32,7 @@ export default function () {
       const payload = JSON.parse(request.requestBody);
 
       if (payload.userId === "192.168.1.1" && payload.password === "Secret") {
-        return new Response(200, {}, { succeeded: true });
+        return new Response(200, {}, { serialNumber: "AAAA-CCCC" });
       }
 
       return new Response(400, {}, {});

--- a/tests/acceptance/authentication-test.js
+++ b/tests/acceptance/authentication-test.js
@@ -52,7 +52,7 @@ module("Acceptance | authentication", function (hooks) {
 
   test("given user authenticated to a device with existing configuration, they are redirected to 'index'", async function (assert) {
     this.server.post(`${ENV.APP.BASE_API_URL}/api/v1/oauth2`, () => {
-      return new Response(200, {}, { succeeded: true, serialNumber: "Dummy" });
+      return new Response(200, {}, { serialNumber: "Dummy" });
     });
     this.server.get(
       `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber`,
@@ -84,7 +84,7 @@ module("Acceptance | authentication", function (hooks) {
 
   test("given user authenticated to a device without existing configuration, they are redirected to 'new network setup'", async function (assert) {
     this.server.post(`${ENV.APP.BASE_API_URL}/api/v1/oauth2`, () => {
-      return new Response(200, {}, { succeeded: true });
+      return new Response(200, {}, { serialNumber: "AAAA-CCCC" });
     });
     this.server.get(
       `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber`,

--- a/tests/unit/authenticators/ucentral-router-test.js
+++ b/tests/unit/authenticators/ucentral-router-test.js
@@ -41,14 +41,14 @@ module("Unit | Authenticator | UcentralRouterAuthenticator", function (hooks) {
   test("#authenticate payload on success is returned", async function (assert) {
     assert.expect(1);
     this.server.post(`${ENV.APP.BASE_API_URL}/api/v1/oauth2`, () => {
-      return new Response(200, {}, { succeeded: true });
+      return new Response(200, {}, { serialNumber: "AAAA-CCCC" });
     });
 
     const data = await this.authenticator.authenticate({
       userId: "192.168.1.1",
       password: "Secret",
     });
-    assert.deepEqual(data, { succeeded: true });
+    assert.deepEqual(data, { serialNumber: "AAAA-CCCC" });
   });
 
   test("#authenticate rejects on bad request", async function (assert) {
@@ -68,9 +68,11 @@ module("Unit | Authenticator | UcentralRouterAuthenticator", function (hooks) {
   test("#restore returns data it received", async function (assert) {
     assert.expect(1);
 
-    const data = await this.authenticator.restore({ succeeded: true });
+    const data = await this.authenticator.restore({
+      serialNumber: "AAAA-CCCC",
+    });
 
-    assert.deepEqual(data, { succeeded: true });
+    assert.deepEqual(data, { serialNumber: "AAAA-CCCC" });
   });
 
   test("#restore throws when it receives empty session object", async function (assert) {


### PR DESCRIPTION
This adds the device's `serialNumber` to the OAuth endpoint.