### PR TITLE
Modify mirage config

### DIFF
--- a/mirage/config.js
+++ b/mirage/config.js
@@ -32,7 +32,25 @@ export default function () {
       const payload = JSON.parse(request.requestBody);
 
       if (payload.userId === "192.168.1.1" && payload.password === "Secret") {
-        return new Response(200, {}, { serialNumber: "AAAA-CCCC" });
+        return new Response(
+          200,
+          {},
+          {
+            succeeded: true,
+            serialNumber: "configured-serial",
+          }
+        );
+      }
+
+      if (payload.userId === "192.168.1.3" && payload.password === "Secret") {
+        return new Response(
+          200,
+          {},
+          {
+            succeeded: true,
+            serialNumber: "unconfigured-serial",
+          }
+        );
       }
 
       return new Response(400, {}, {});
@@ -49,16 +67,12 @@ export default function () {
   this.get(
     `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber`,
     function (schema, request) {
-      if (request.params.serialNumber === "configured-serial") {
-        return new Response(
-          200,
-          {},
-          {
-            configuration: "true",
-            serialNumber: "AAAA-CCCC",
-            name: "Dummy",
-          }
-        );
+      const foundDevice = schema.db.devices.findBy({
+        serialNumber: request.params.serialNumber,
+      });
+
+      if (foundDevice) {
+        return new Response(200, {}, foundDevice);
       }
 
       return new Response(
@@ -98,6 +112,7 @@ export default function () {
       );
     }
   );
+
   this.get(
     `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber`,
     function (schema, request) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -59,8 +59,17 @@ export default function () {
 
   this.post(
     `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/configure`,
-    function () {
-      return new Response(200, {}, {});
+    function (schema, request) {
+      const foundDevice = schema.db.devices.findBy({
+        serialNumber: request.params.serialNumber,
+      });
+
+      const updatedDevice = schema.db.devices.update(
+        foundDevice,
+        JSON.parse(request.requestBody)
+      );
+
+      return new Response(200, {}, updatedDevice);
     }
   );
 
@@ -112,7 +121,6 @@ export default function () {
       );
     }
   );
-
   this.get(
     `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber`,
     function (schema, request) {

--- a/mirage/fixtures/devices.js
+++ b/mirage/fixtures/devices.js
@@ -23,4 +23,25 @@ export default [
     location: "Office 1",
     connectedDevicesCount: 0,
   },
+  {
+    UUID: "4-4",
+    serialNumber: "configured-serial",
+    deviceType: "AP",
+    macAddress: "00:1A:C4",
+    location: "Office 2",
+    connectedDevicesCount: 0,
+    configuration: JSON.stringify({
+      ssid: "Some SSID",
+      password: "Secret",
+      encryption: "wpa2",
+    }),
+  },
+  {
+    UUID: "5-5",
+    serialNumber: "unconfigured-serial",
+    deviceType: "AP",
+    macAddress: "00:1A:C5",
+    location: "Office 3",
+    connectedDevicesCount: 0,
+  },
 ];


### PR DESCRIPTION
Adds fixtures for 2 devices that can be logged in to by entering `192.168.1.1` and `192.168.1.3` ip addresses, the first one is configured so it should redirect to dashboard, the other one is unconfigured so user should land on new setup screen.