### PR TITLE
feat: change configure request for new-setup

### DIFF
--- a/app/components/new-setup.js
+++ b/app/components/new-setup.js
@@ -13,6 +13,7 @@ const STEPS = {
 
 export default class NewSetupComponent extends Component {
   @service currentDevice;
+  @service session;
   @service intl;
 
   @tracked networkName = "";
@@ -71,12 +72,14 @@ export default class NewSetupComponent extends Component {
   async configureDevice() {
     try {
       const response = await fetch(
-        `${ENV.APP.BASE_API_URL}/api/v1/device/${this.currentDevice.data.serialNumber}/configure`,
+        `${ENV.APP.BASE_API_URL}/api/v1/device/${this.session.data.authenticated.serialNumber}/configure`,
         {
           method: "POST",
           body: JSON.stringify({
-            ssid: this.networkName,
-            password: this.networkPassword,
+            configuration: {
+              ssid: this.networkName,
+              password: this.networkPassword,
+            },
           }),
         }
       );

--- a/tests/integration/components/new-setup-test.js
+++ b/tests/integration/components/new-setup-test.js
@@ -8,6 +8,7 @@ import dotStyles from "ucentral/components/uc/progress/dot.css";
 import strikethroughStyles from "ucentral/components/uc/progress/strikethrough.css";
 import { Response } from "miragejs";
 import ENV from "ucentral/config/environment";
+import { authenticateSession } from "ember-simple-auth/test-support";
 
 const goToPasswordStep = async (networkName = "some name") => {
   await fillIn("[data-test-network-name] [data-test-input]", networkName);
@@ -227,8 +228,7 @@ module("Integration | Component | NewSetup", function (hooks) {
     test("request is sent with correct serial number", async function (assert) {
       assert.expect(1);
 
-      const currentDeviceService = this.owner.lookup("service:currentDevice");
-      currentDeviceService.data = { serialNumber: "1111-AAAA-BBBB" };
+      await authenticateSession({ serialNumber: "1111-AAAA-BBBB" });
       this.server.post(
         `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/configure`,
         function (schema, request) {
@@ -243,14 +243,15 @@ module("Integration | Component | NewSetup", function (hooks) {
     test("request receives ssid and password in payload", async function (assert) {
       assert.expect(1);
 
-      const currentDeviceService = this.owner.lookup("service:currentDevice");
-      currentDeviceService.serialNumber = "1111-AAAA-BBBB";
+      await authenticateSession({ serialNumber: "1111-AAAA-BBBB" });
       this.server.post(
         `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/configure`,
         function (schema, request) {
           assert.deepEqual(JSON.parse(request.requestBody), {
-            ssid: "Network_1",
-            password: "Password_1",
+            configuration: {
+              ssid: "Network_1",
+              password: "Password_1",
+            },
           });
         }
       );


### PR DESCRIPTION
/configure requests in other parts of the app send nested `configuration` payload, so this PR aligns new-setup with that.
During new-setup the device that is being configured may be not always loaded in case of a refresh so we should use session data to construct the URL.