### PR TITLE
refactor: change endpoint paths from plural to singular

### DIFF
--- a/app/components/network-map/detail.js
+++ b/app/components/network-map/detail.js
@@ -9,7 +9,7 @@ export default class NetworkMapDetailComponent extends Component {
   *loadHealthChecksTask(serialNumber) {
     try {
       const response = yield this.http.get(
-        `/api/v1/devices/${serialNumber}/healthchecks`
+        `/api/v1/device/${serialNumber}/healthchecks`
       );
 
       if (response.ok) {

--- a/app/components/network-map/item.js
+++ b/app/components/network-map/item.js
@@ -9,7 +9,7 @@ export default class NetworkMapItemComponent extends Component {
   *loadHealthChecksTask(serialNumber) {
     try {
       const response = yield this.http.get(
-        `/api/v1/devices/${serialNumber}/healthchecks`
+        `/api/v1/device/${serialNumber}/healthchecks`
       );
 
       if (response.ok) {

--- a/app/routes/network-map/show.js
+++ b/app/routes/network-map/show.js
@@ -14,7 +14,7 @@ export default class NetworkMapDetailRoute extends Route {
 
   async loadDevice(serialNumber) {
     try {
-      const response = await this.http.get(`/api/v1/devices/${serialNumber}`);
+      const response = await this.http.get(`/api/v1/device/${serialNumber}`);
 
       if (response.ok) {
         return response.json();
@@ -29,7 +29,7 @@ export default class NetworkMapDetailRoute extends Route {
   async loadConnectedDevices(serialNumber) {
     try {
       const response = await this.http.get(
-        `/api/v1/devices/${serialNumber}/connectedDevices`
+        `/api/v1/device/${serialNumber}/connectedDevices`
       );
 
       if (response.ok) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -87,7 +87,7 @@ export default function () {
   });
 
   this.get(
-    `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber/healthchecks`,
+    `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/healthchecks`,
     function (schema, request) {
       return new Response(
         200,
@@ -98,19 +98,9 @@ export default function () {
       );
     }
   );
-  this.get(
-    `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber`,
-    function (schema, request) {
-      const device = schema.db.devices.findBy({
-        serialNumber: request.params.serialNumber,
-      });
-
-      return new Response(200, {}, device);
-    }
-  );
 
   this.get(
-    `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber/connectedDevices`,
+    `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/connectedDevices`,
     function (schema) {
       return new Response(200, {}, schema.db.devices.toArray());
     }

--- a/tests/acceptance/network-map-test.js
+++ b/tests/acceptance/network-map-test.js
@@ -197,7 +197,7 @@ module("Acceptance | network-map", function (hooks) {
   module("/Show", function () {
     test("shows connected devices list", async function (assert) {
       this.server.get(
-        `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber/connectedDevices`,
+        `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/connectedDevices`,
         function () {
           return [{ serialNumber: "1" }, { serialNumber: "2" }];
         }
@@ -211,7 +211,7 @@ module("Acceptance | network-map", function (hooks) {
 
     test("shows connected devices sumnmary", async function (assert) {
       this.server.get(
-        `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber`,
+        `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber`,
         function () {
           return new Response(200, {}, [
             {
@@ -222,7 +222,7 @@ module("Acceptance | network-map", function (hooks) {
         }
       );
       this.server.get(
-        `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber/connectedDevices`,
+        `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/connectedDevices`,
         function () {
           return [
             {

--- a/tests/integration/components/network-map/detail-test.js
+++ b/tests/integration/components/network-map/detail-test.js
@@ -14,7 +14,7 @@ module("Integration | Component | NetworkMap::Detail", function (hooks) {
   module("Access Point", function () {
     test("shows network health text", async function (assert) {
       this.server.get(
-        `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber`,
+        `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber`,
         function () {
           return new Response(400, {}, {});
         }
@@ -28,7 +28,7 @@ module("Integration | Component | NetworkMap::Detail", function (hooks) {
 
     test("shows network health status", async function (assert) {
       this.server.get(
-        `${ENV.APP.BASE_API_URL}/api/v1/devices/:serialNumber/healthchecks`,
+        `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/healthchecks`,
         function () {
           return {
             serialNumber: "TEST-TEST",


### PR DESCRIPTION
According to API spec when querying a device by serialNumber, the correct path is `/device` not `/devices`