### PR TITLE
Add setup success route

### DIFF
--- a/app/components/new-setup.js
+++ b/app/components/new-setup.js
@@ -3,7 +3,6 @@ import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
 import { task } from "ember-concurrency-decorators";
 import { inject as service } from "@ember/service";
-import ENV from "ucentral/config/environment";
 
 const STEPS = {
   NETWORK_NAME: "NETWORK_NAME",
@@ -70,23 +69,10 @@ export default class NewSetupComponent extends Component {
 
   async configureDevice() {
     try {
-      const response = await fetch(
-        `${ENV.APP.BASE_API_URL}/api/v1/device/${this.currentDevice.data.serialNumber}/configure`,
-        {
-          method: "POST",
-          body: JSON.stringify({
-            ssid: this.networkName,
-            password: this.networkPassword,
-          }),
-        }
+      const response = await this.currentDevice.configure(
+        this.networkName,
+        this.networkPassword
       );
-
-      if (!response.ok) {
-        return {
-          ok: false,
-          errorMessage: this.intl.t("errors.somethingWentWrong"),
-        };
-      }
 
       return response;
     } catch (error) {

--- a/app/components/new-setup.js
+++ b/app/components/new-setup.js
@@ -13,6 +13,7 @@ const STEPS = {
 export default class NewSetupComponent extends Component {
   @service currentDevice;
   @service intl;
+  @service router;
 
   @tracked networkName = "";
   @tracked networkPassword = "";
@@ -62,8 +63,10 @@ export default class NewSetupComponent extends Component {
 
       if (!configureDeviceResponse.ok) {
         this.goToStep(STEPS.NETWORK_NAME);
+        return configureDeviceResponse;
       }
-      return configureDeviceResponse;
+
+      this.router.transitionTo("network-setup.success");
     }
   }
 

--- a/app/components/setup-success.css
+++ b/app/components/setup-success.css
@@ -1,0 +1,3 @@
+.dashboard-link {
+  @apply mt-6 text-blue-600 block text-center uppercase p-3;
+}

--- a/app/components/setup-success.hbs
+++ b/app/components/setup-success.hbs
@@ -1,0 +1,16 @@
+<Uc::Layout>
+  <:title>
+    {{t "network_setup.success.title"}}
+  </:title>
+
+  <:description>
+    {{t "network_setup.success.description" deviceName=this.currentDevice.data.name htmlSafe=true}}
+  </:description>
+
+  <:content as |content|>
+    <content.Wrapper>
+      <main>
+      </main>
+    </content.Wrapper>
+  </:content>
+</Uc::Layout>

--- a/app/components/setup-success.hbs
+++ b/app/components/setup-success.hbs
@@ -9,7 +9,11 @@
 
   <:content as |content|>
     <content.Wrapper>
-      <main>
+      <main data-test-setup-success>
+        <Uc::NetworkQrCode @ssid={{this.currentDevice.data.configuration.ssid}} @password={{this.currentDevice.data.configuration.password}} @encryption={{this.currentDevice.data.configuration.encryption}} @isHidden={{this.currentDevice.configuration.data.hidden}} data-test-qr-code />
+        <LinkTo @route="index" local-class="dashboard-link" data-test-dashboard-link>
+          {{t "network_setup.success.go_to_dashboard"}}
+        </LinkTo>
       </main>
     </content.Wrapper>
   </:content>

--- a/app/components/setup-success.js
+++ b/app/components/setup-success.js
@@ -1,0 +1,6 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class SetupSuccessComponent extends Component {
+  @service currentDevice;
+}

--- a/app/router.js
+++ b/app/router.js
@@ -10,6 +10,7 @@ Router.map(function () {
   this.route("auth");
   this.route("network-setup", function () {
     this.route("new");
+    this.route("success");
   });
   this.route("qr-code");
 

--- a/app/routes/network-setup.js
+++ b/app/routes/network-setup.js
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 
-export default class IndexRoute extends Route {
+export default class NetworkSetupRoute extends Route {
   @service session;
 
   beforeModel(transition) {

--- a/app/routes/network-setup.js
+++ b/app/routes/network-setup.js
@@ -3,8 +3,13 @@ import { inject as service } from "@ember/service";
 
 export default class NetworkSetupRoute extends Route {
   @service session;
+  @service currentDevice;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, "auth");
+  }
+
+  model() {
+    return this.currentDevice.load();
   }
 }

--- a/app/routes/network-setup/success.js
+++ b/app/routes/network-setup/success.js
@@ -1,0 +1,18 @@
+import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
+
+export default class ApplicationRoute extends Route {
+  @service currentDevice;
+
+  beforeModel() {
+    let { configuration } = this.currentDevice.data;
+    let { ssid, encryption, password } = configuration || {};
+    let allRequiredValuesPresent = [ssid, encryption, password].every(
+      (e) => e !== null && e !== undefined
+    );
+
+    if (!allRequiredValuesPresent) {
+      this.transitionTo("index");
+    }
+  }
+}

--- a/app/templates/network-setup/success.hbs
+++ b/app/templates/network-setup/success.hbs
@@ -1,0 +1,4 @@
+{{page-title "New setup"}}
+
+<SetupSuccess />
+

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -64,10 +64,13 @@ export default function () {
         serialNumber: request.params.serialNumber,
       });
 
-      const updatedDevice = schema.db.devices.update(
-        foundDevice,
-        JSON.parse(request.requestBody)
-      );
+      const body = JSON.parse(request.requestBody);
+      const [updatedDevice] = schema.db.devices.update(foundDevice, {
+        configuration: {
+          ...body.configuration,
+          encryption: "wpa2",
+        },
+      });
 
       return new Response(200, {}, updatedDevice);
     }

--- a/mirage/fixtures/devices.js
+++ b/mirage/fixtures/devices.js
@@ -34,6 +34,7 @@ export default [
       ssid: "Some SSID",
       password: "Secret",
       encryption: "wpa2",
+      hidden: false,
     }),
   },
   {

--- a/tests/acceptance/network-setup-test.js
+++ b/tests/acceptance/network-setup-test.js
@@ -1,0 +1,83 @@
+import { module, test } from "qunit";
+import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
+import { setupApplicationTest } from "ember-qunit";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import {
+  authenticateSession,
+  invalidateSession,
+} from "ember-simple-auth/test-support";
+import ENV from "ucentral/config/environment";
+
+module("Acceptance | network-setup", function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  test("when not authenticated, redirects to /auth", async function (assert) {
+    await invalidateSession();
+    await visit("/network-setup/new");
+
+    assert.equal(currentURL(), "/auth");
+  });
+
+  test("is accssible when authenticated", async function (assert) {
+    await authenticateSession();
+    await visit("/network-setup/new");
+
+    assert.equal(currentURL(), "/network-setup/new");
+  });
+
+  test("setting up a network works", async function (assert) {
+    this.server.get(
+      `${ENV.APP.BASE_API_URL}/api/v1/device/1111-AAAA-BBBB`,
+      function () {
+        return {
+          configuration: "true",
+          serialNumber: "1111-AAAA-BBBB",
+          name: "Dummy",
+        };
+      }
+    );
+    this.server.post(
+      `${ENV.APP.BASE_API_URL}/api/v1/device/1111-AAAA-BBBB/configure`,
+      function () {
+        return {
+          configuration: {
+            ssid: "the-ssid",
+            password: "mypass",
+            encryption: "wpa2",
+            hidden: true,
+          },
+        };
+      }
+    );
+
+    await authenticateSession({ serialNumber: "1111-AAAA-BBBB" });
+    await visit("/network-setup/new");
+    await fillIn("[data-test-network-name] [data-test-input]", "my-wifi");
+    await click("[data-test-confirm-button]");
+    await fillIn(
+      "[data-test-network-password] [data-test-input]",
+      "some password"
+    );
+    await click("[data-test-confirm-button]");
+
+    assert.equal(currentURL(), "/network-setup/success");
+  });
+
+  test("the network-setup.success route transitions to index when no configuration is currently known", async function (assert) {
+    await authenticateSession({ serialNumber: "1111-AAAA-BBBB" });
+    this.server.get(
+      `${ENV.APP.BASE_API_URL}/api/v1/device/1111-AAAA-BBBB`,
+      function () {
+        return {
+          configuration: "true",
+          serialNumber: "1111-AAAA-BBBB",
+          name: "Dummy",
+        };
+      }
+    );
+    await visit("/network-setup/success");
+
+    assert.equal(currentURL(), "/");
+  });
+});

--- a/tests/integration/components/new-setup-test.js
+++ b/tests/integration/components/new-setup-test.js
@@ -147,7 +147,14 @@ module("Integration | Component | NewSetup", function (hooks) {
         this.server.post(
           `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/configure`,
           function () {
-            return new Response(200, {}, {});
+            return {
+              configuration: {
+                ssid: "the-ssid",
+                password: "mypass",
+                encryption: "wpa2",
+                hidden: true,
+              },
+            };
           }
         );
       });
@@ -249,8 +256,10 @@ module("Integration | Component | NewSetup", function (hooks) {
         `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/configure`,
         function (schema, request) {
           assert.deepEqual(JSON.parse(request.requestBody), {
-            ssid: "Network_1",
-            password: "Password_1",
+            configuration: {
+              ssid: "Network_1",
+              password: "Password_1",
+            },
           });
         }
       );

--- a/tests/integration/components/setup-success-test.js
+++ b/tests/integration/components/setup-success-test.js
@@ -1,0 +1,38 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { render } from "@ember/test-helpers";
+import Service from "@ember/service";
+import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
+
+module("Integration | Component | SetupSuccess", function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(function () {
+    this.owner.register(
+      "service:current-device",
+      class MockCurrentDeviceService extends Service {
+        data = {
+          configuration: {
+            ssid: "SSID",
+            password: "my-secr0t!",
+            encryption: "wpa2",
+          },
+        };
+      }
+    );
+  });
+
+  test("it renders the QR code", async function (assert) {
+    await render(hbs`<SetupSuccess />`);
+
+    assert.dom("[data-test-qr-code]").exists();
+  });
+
+  test("it renders a link to the dashboard", async function (assert) {
+    await render(hbs`<SetupSuccess />`);
+
+    assert.dom("[data-test-qr-code]").exists();
+  });
+});

--- a/tests/unit/services/current-device-test.js
+++ b/tests/unit/services/current-device-test.js
@@ -1,0 +1,64 @@
+import { module, test } from "qunit";
+import { setupTest } from "ember-qunit";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import ENV from "ucentral/config/environment";
+
+module("Unit | Service | current-device", function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.subject = this.owner.lookup("service:current-device");
+  });
+
+  module("#configure", function () {
+    test("it makes the correct request", async function (assert) {
+      this.subject.data.serialNumber = "AAAA-CCCC";
+      this.server.post(
+        `${ENV.APP.BASE_API_URL}/api/v1/device/AAAA-CCCC/configure`,
+        function (schema, request) {
+          assert.deepEqual(JSON.parse(request.requestBody), {
+            configuration: {
+              ssid: "ssid",
+              password: "password",
+            },
+          });
+
+          return {
+            configuration: {},
+          };
+        }
+      );
+
+      await this.subject.configure("ssid", "password");
+    });
+
+    test("it udpates its data with the response", async function (assert) {
+      this.subject.data.serialNumber = "AAAA-CCCC";
+      this.server.post(
+        `${ENV.APP.BASE_API_URL}/api/v1/device/AAAA-CCCC/configure`,
+        function () {
+          return {
+            configuration: {
+              ssid: "the-ssid",
+              password: "mypass",
+              encryption: "wpa2",
+              hidden: true,
+            },
+          };
+        }
+      );
+      await this.subject.configure("ssid", "password");
+
+      assert.deepEqual(this.subject.data, {
+        serialNumber: "AAAA-CCCC",
+        configuration: {
+          ssid: "the-ssid",
+          password: "mypass",
+          encryption: "wpa2",
+          hidden: true,
+        },
+      });
+    });
+  });
+});

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -60,6 +60,10 @@
     "applying_settings": {
       "title": "Just a moment, we're applying your settings",
       "description": "Your <b>{deviceName}</b> mesh network is getting started..."
+    },
+    "success": {
+      "title": "Success!",
+      "description": "Your <b>{deviceName}</b> mesh network is set up. You can connect via your device’s settings.<br/><br/>Use this QR code to connect other devices."
     }
   },
   "network_settings": {

--- a/translations/en-us.json
+++ b/translations/en-us.json
@@ -63,7 +63,8 @@
     },
     "success": {
       "title": "Success!",
-      "description": "Your <b>{deviceName}</b> mesh network is set up. You can connect via your device’s settings.<br/><br/>Use this QR code to connect other devices."
+      "description": "Your <b>{deviceName}</b> mesh network is set up. You can connect via your device’s settings.<br/><br/>Use this QR code to connect other devices.",
+      "go_to_dashboard": "View network dashboard"
     }
   },
   "network_settings": {


### PR DESCRIPTION
This adds the setup success route that shows the QR code for the configured network:

![localhost_4200_network-setup_new(Moto G4)](https://user-images.githubusercontent.com/1510/122379003-bf6ae680-cf66-11eb-85c2-9dd215ca944a.png)

This also moves the configuration of the network into the `currentDevice` service (out of the `<NewSetup>` component) so the configured values are available there and can be used on the next screen which is the success screen.

This also changes the mock response for the network configuration call to include all relevant settings (such as encryption and hidden) that we need in order to show the QR code but cannot know unless we get them from the device. We can also not reload the configuration from the device after applying it since we have to assume the device is restarting and unaivailable.

closes #29 