### PR TITLE
use `<Uc::PasswordInput>` for network setup

### DIFF
--- a/app/components/new-setup.hbs
+++ b/app/components/new-setup.hbs
@@ -60,11 +60,11 @@
           {{/if}}
 
           {{#if this.isNetworkPasswordStep}}
-            <Uc::Input
-              local-class="input"
+            <Uc::PasswordInput
               @label={{t "network_setup.wifi_password.label"}}
               @value={{this.networkPassword}}
               @onInput={{this.handleNetworkPassword}}
+              local-class="input"
               data-test-network-password
             />
 

--- a/tests/acceptance/network-setup-test.js
+++ b/tests/acceptance/network-setup-test.js
@@ -56,7 +56,7 @@ module("Acceptance | network-setup", function (hooks) {
     await fillIn("[data-test-network-name] [data-test-input]", "my-wifi");
     await click("[data-test-confirm-button]");
     await fillIn(
-      "[data-test-network-password] [data-test-input]",
+      "[data-test-network-password] [data-test-password-input]",
       "some password"
     );
     await click("[data-test-confirm-button]");

--- a/tests/integration/components/new-setup-test.js
+++ b/tests/integration/components/new-setup-test.js
@@ -21,7 +21,7 @@ const goToApplyingSettingsStep = async ({
 } = {}) => {
   await goToPasswordStep(networkName);
   await fillIn(
-    "[data-test-network-password] [data-test-input]",
+    "[data-test-network-password] [data-test-password-input]",
     networkPassword
   );
   return click("[data-test-confirm-button]");
@@ -127,7 +127,7 @@ module("Integration | Component | NewSetup", function (hooks) {
         await goToPasswordStep();
 
         assert
-          .dom("[data-test-network-password] [data-test-input]")
+          .dom("[data-test-network-password] [data-test-password-input]")
           .hasNoValue();
         assert.dom("[data-test-confirm-button]").hasAttribute("disabled");
       });
@@ -295,7 +295,7 @@ module("Integration | Component | NewSetup", function (hooks) {
       await render(hbs`<NewSetup />`);
       await goToPasswordStep();
       await fillIn(
-        "[data-test-network-password] [data-test-input]",
+        "[data-test-network-password] [data-test-password-input]",
         "some password"
       );
 
@@ -331,7 +331,7 @@ module("Integration | Component | NewSetup", function (hooks) {
       await render(hbs`<NewSetup />`);
       await goToPasswordStep();
       await fillIn(
-        "[data-test-network-password] [data-test-input]",
+        "[data-test-network-password] [data-test-password-input]",
         "some password"
       );
       await click("[data-test-confirm-button]");


### PR DESCRIPTION
This changes the input for the password when setting up the wifi to be a `<Uc::PasswordInput>` instead of a `<Uc::Input>`:

| Before | After |
|-----|-----|
| ![localhost_4200_(Moto G4)](https://user-images.githubusercontent.com/1510/122398220-f7c7f000-cf79-11eb-8883-01a6a3048804.png) | ![localhost_4200_network-setup_new(Moto G4)](https://user-images.githubusercontent.com/1510/122398243-fc8ca400-cf79-11eb-9087-a5e473966792.png) |