### PR TITLE
add missing padding to QR code route

### DIFF
--- a/app/components/qr-code.hbs
+++ b/app/components/qr-code.hbs
@@ -2,7 +2,9 @@
   <:navigation><Uc::Layout::BackNavigation @route="index" /></:navigation>
   <:title>{{t "qr_code.title"}}</:title>
   <:description>{{t "qr_code.description" ssid=@ssid}}</:description>
-  <:content>
-    <Uc::NetworkQrCode @ssid={{@ssid}} @password={{@password}} @encryption={{@encryption}} @isHidden={{@isHidden}} data-test-qr-code />
+  <:content as |content|>
+    <content.Wrapper>
+      <Uc::NetworkQrCode @ssid={{@ssid}} @password={{@password}} @encryption={{@encryption}} @isHidden={{@isHidden}} data-test-qr-code />
+    </content.Wrapper>
   </:content>
 </Uc::Layout>


### PR DESCRIPTION
This adds missing padding to the left and right of the QR code route:

| Before | After |
|-----|------|
| ![localhost_4200_(Moto G4)](https://user-images.githubusercontent.com/1510/122398828-8dfc1600-cf7a-11eb-883d-33f372b50f09.png) | ![localhost_4200_qr-code(Moto G4)](https://user-images.githubusercontent.com/1510/122398853-96ece780-cf7a-11eb-95d2-cfac85d5274d.png) |