### PR TITLE
Remove network settings endpoint

### DIFF
--- a/app/components/qr-code.hbs
+++ b/app/components/qr-code.hbs
@@ -1,10 +1,10 @@
 <Uc::Layout>
   <:navigation><Uc::Layout::BackNavigation @route="index" /></:navigation>
   <:title>{{t "qr_code.title"}}</:title>
-  <:description>{{t "qr_code.description" ssid=@ssid}}</:description>
+  <:description>{{t "qr_code.description" ssid=this.currentDevice.data.configuration.ssid}}</:description>
   <:content as |content|>
     <content.Wrapper>
-      <Uc::NetworkQrCode @ssid={{@ssid}} @password={{@password}} @encryption={{@encryption}} @isHidden={{@isHidden}} data-test-qr-code />
+      <Uc::NetworkQrCode @ssid={{this.currentDevice.data.configuration.ssid}} @password={{this.currentDevice.data.configuration.password}} @encryption={{this.currentDevice.data.configuration.encryption}} @isHidden={{this.currentDevice.data.configuration.hidden}} data-test-qr-code />
     </content.Wrapper>
   </:content>
 </Uc::Layout>

--- a/app/components/qr-code.js
+++ b/app/components/qr-code.js
@@ -1,0 +1,6 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+
+export default class QrCodeComponent extends Component {
+  @service currentDevice;
+}

--- a/app/routes/qr-code.js
+++ b/app/routes/qr-code.js
@@ -3,25 +3,13 @@ import { inject as service } from "@ember/service";
 
 export default class QrCodeRoute extends Route {
   @service session;
+  @service currentDevice;
 
   beforeModel(transition) {
     this.session.requireAuthentication(transition, "auth");
   }
 
-  async model() {
-    let response = await fetch("/network-settings");
-    let {
-      ssid,
-      password,
-      encryption,
-      hidden: isHidden,
-    } = await response.json();
-
-    return {
-      ssid,
-      password,
-      encryption,
-      isHidden,
-    };
+  model() {
+    return this.currentDevice.load();
   }
 }

--- a/app/templates/qr-code.hbs
+++ b/app/templates/qr-code.hbs
@@ -1,1 +1,1 @@
-<QrCode @ssid={{@model.ssid}} @password={{@model.password}} @encryption={{@model.encryption}} @isHidden={{@model.isHidden}} />
+<QrCode />

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -85,19 +85,6 @@ export default function () {
     }
   );
 
-  this.get("/network-settings", function () {
-    return new Response(
-      200,
-      { "content-type": "application/json" },
-      {
-        ssid: "mynetwork",
-        password: "mypass",
-        encryption: "wpa2",
-        hidden: false,
-      }
-    );
-  });
-
   this.get(
     `${ENV.APP.BASE_API_URL}/api/v1/device/:serialNumber/healthchecks`,
     function (schema, request) {

--- a/mirage/fixtures/devices.js
+++ b/mirage/fixtures/devices.js
@@ -34,12 +34,12 @@ export default [
     macAddress: "00:1A:C4",
     location: "Office 2",
     connectedDevicesCount: 0,
-    configuration: JSON.stringify({
+    configuration: {
       ssid: "Some SSID",
       password: "Secret",
       encryption: "wpa2",
       hidden: false,
-    }),
+    },
   },
   {
     UUID: "5-5",


### PR DESCRIPTION
This removes the `GET /network-settings` endpoint that we only made up anyway and instead loads the settings for the QR code route via the `current-device` service.