### PR TITLE
remove link underline

### DIFF
--- a/app/components/setup-success.css
+++ b/app/components/setup-success.css
@@ -1,3 +1,3 @@
 .dashboard-link {
-  @apply mt-6 text-blue-600 block text-center uppercase p-3;
+  @apply mt-6 text-blue-600 block text-center uppercase p-3 no-underline;
 }


### PR DESCRIPTION
This removes the unwanted link underline from the setup success screen:

| Before | After |
|-----|-----|
| ![zealous-mahavira-6ac0ef netlify app_(Moto G4)](https://user-images.githubusercontent.com/1510/122402480-cea95e80-cf7d-11eb-9789-f0bc75af85ab.png) | ![localhost_4200_(Moto G4)](https://user-images.githubusercontent.com/1510/122402510-d6690300-cf7d-11eb-9473-0b87f9501c50.png) |